### PR TITLE
ci: remove unnecessary strategy property

### DIFF
--- a/.github/workflows/correctness.yaml
+++ b/.github/workflows/correctness.yaml
@@ -3,29 +3,27 @@ name: Correctness
 on:
   workflow_call:
   push:
-    branches: [ 'main', 'dev' ]
+    branches: ['main', 'dev']
   pull_request:
-    branches: [ 'main', 'dev' ]
+    branches: ['main', 'dev']
 
 jobs:
   correctness:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Run image
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: 1.2.2
       - name: Create environment
-        run:  poetry install
+        run: poetry install
       - name: Pylint source
-        run:  poetry run pylint ./tds
+        run: poetry run pylint ./tds
       - name: Pylint tests
-        run:  poetry run pylint ./tests
+        run: poetry run pylint ./tests
       - name: Pytest
-        run:  poetry run pytest
+        run: poetry run pytest

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -3,27 +3,25 @@ name: Formatting
 on:
   workflow_call:
   push:
-    branches: [ 'main', 'dev' ]
+    branches: ['main', 'dev']
   pull_request:
-    branches: [ 'main', 'dev' ]
+    branches: ['main', 'dev']
 
 jobs:
   formatting:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Run image
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: 1.2.2
       - name: Create environment
-        run:  poetry install
-      - name: Black 
-        run:  poetry run black . --check --verbose
+        run: poetry install
+      - name: Black
+        run: poetry run black . --check --verbose
       - name: isort
-        run:  poetry run isort . --check
+        run: poetry run isort . --check


### PR DESCRIPTION
Removing the `strategy` property with `fail-fast`. Fail fast only applies when a `matrix` strategy is used and in this case it is not so the property is a noop.

