### PR TITLE
Fix REST subobject pattern

### DIFF
--- a/tds/routers/datasets.py
+++ b/tds/routers/datasets.py
@@ -210,15 +210,12 @@ def delete_qualifier(id: int, rdb: Engine = Depends(request_rdb)) -> str:
 def get_datasets(
     page_size: int = 100,
     page: int = 0,
-    is_simulation: Optional[bool] = None,
     rdb: Engine = Depends(request_rdb),
 ):
     """
     Get a specific number of datasets
     """
     with Session(rdb) as session:
-        if is_simulation:  # Deprecated, makes pylint pass.
-            pass
         datasets = (
             session.query(orm.Dataset)
             .order_by(orm.Dataset.id.asc())

--- a/tds/routers/models.py
+++ b/tds/routers/models.py
@@ -168,7 +168,7 @@ def list_model_descriptions(
     return list_by_id(rdb.connect(), orm.ModelDescription, page_size, page)
 
 
-@router.get("/descriptions/{id}", **retrieve.fastapi_endpoint_config)
+@router.get("/{id}/descriptions", **retrieve.fastapi_endpoint_config)
 def get_model_description(
     id: int, rdb: Engine = Depends(request_rdb)
 ) -> ModelDescription:
@@ -184,7 +184,7 @@ def get_model_description(
 
 
 @router.get("/model_parameters/{id}", **retrieve.fastapi_endpoint_config)
-def get_model_parameter(id: int, rdb: Engine = Depends(request_rdb)):
+def get_single_model_parameter(id: int, rdb: Engine = Depends(request_rdb)):
     """
     Retrieve model parameter
     """
@@ -199,7 +199,7 @@ def get_model_parameter(id: int, rdb: Engine = Depends(request_rdb)):
         raise HTTPException(status_code=status.HTTP_404_NOT_F)
 
 
-@router.get("/parameters/{id}", **retrieve.fastapi_endpoint_config)
+@router.get("/{id}/parameters", **retrieve.fastapi_endpoint_config)
 def get_model_parameters(
     id: int, rdb: Engine = Depends(request_rdb)
 ) -> ModelParameters:
@@ -216,7 +216,7 @@ def get_model_parameters(
     return orm_to_params(list(parameters))
 
 
-@router.put("/parameters/{id}", **update.fastapi_endpoint_config)
+@router.put("/{id}/parameters", **update.fastapi_endpoint_config)
 def update_model_parameters(
     payload: ModelParameters, id: int, rdb: Engine = Depends(request_rdb)
 ) -> Response:

--- a/tds/routers/simulations.py
+++ b/tds/routers/simulations.py
@@ -85,7 +85,7 @@ def list_run_descriptions(
     return list_by_id(rdb.connect(), orm.SimulationRun, page_size, page)
 
 
-@router.get("/runs/descriptions/{id}", **retrieve.fastapi_endpoint_config)
+@router.get("/runs/{id}/descriptions", **retrieve.fastapi_endpoint_config)
 def get_run_description(id: int, rdb: Engine = Depends(request_rdb)) -> RunDescription:
     """
     Retrieve run metadata
@@ -121,7 +121,7 @@ def create_run_from_description(
 
 
 @router.get("/simulation_parameters/{id}", **retrieve.fastapi_endpoint_config)
-def get_simulation_parameter(id: int, rdb: Engine = Depends(request_rdb)):
+def get_single_simulation_parameter(id: int, rdb: Engine = Depends(request_rdb)):
     """
     Retrieve simulation parameter
     """
@@ -136,7 +136,7 @@ def get_simulation_parameter(id: int, rdb: Engine = Depends(request_rdb)):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
-@router.get("/runs/parameters/{id}", **retrieve.fastapi_endpoint_config)
+@router.get("/runs/{id}/parameters", **retrieve.fastapi_endpoint_config)
 def get_run_parameters(
     id: int, rdb: Engine = Depends(request_rdb)
 ) -> SimulationParameters:
@@ -152,7 +152,7 @@ def get_run_parameters(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
-@router.put("/runs/parameters/{id}", **update.fastapi_endpoint_config)
+@router.put("/runs/{id}/parameters", **update.fastapi_endpoint_config)
 def update_run_parameters(
     payload: SimulationParameters, id: int, rdb: Engine = Depends(request_rdb)
 ) -> Response:


### PR DESCRIPTION
Fixes the subobject pattern on the model and simulation routers. Also, the `is_simulation` flag has been removed from datasets