### PR TITLE
164 parameterize neo4jpostgres initialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - data-api
   api:
     container_name: data-service-api
-    build: 
+    build:
       context: ./
       dockerfile: docker/Dockerfile
     ports:
@@ -49,8 +49,6 @@ services:
       - 7474:7474
       - 7687:7687
     environment:
-      - NEO4J_PLUGINS=["apoc"]
-      - apoc.import.file.enabled=true
       - NEO4J_AUTH=neo4j/password
       - NEO4J_dbms_memory_pagecache_size=512M
     depends_on:

--- a/docker/Dockerfile.neo4j
+++ b/docker/Dockerfile.neo4j
@@ -1,7 +1,10 @@
-FROM neo4j:latest 
+FROM neo4j:5.3.0
 # TODO: Use the postgres image directly instead of stateful install
 RUN apt update 2> /dev/null
 RUN apt install -y postgresql postgresql-contrib netcat
+
+ENV NEO4J_PLUGINS=["apoc"]
+ENV apoc.import.file.enabled=true
 
 COPY ./docker/scripts/start-neo4j.sh /entrypoint.sh
 COPY ./docker/scripts/populate-cache.cypher /tmp/populate-cache.cypher

--- a/docker/Dockerfile.neo4j
+++ b/docker/Dockerfile.neo4j
@@ -3,7 +3,7 @@ FROM neo4j:5.3.0
 RUN apt update 2> /dev/null
 RUN apt install -y postgresql postgresql-contrib netcat
 
-ENV NEO4J_PLUGINS=["apoc"]
+ENV NEO4J_PLUGINS=[\"apoc\"]
 ENV apoc.import.file.enabled=true
 
 COPY ./docker/scripts/start-neo4j.sh /entrypoint.sh

--- a/docker/scripts/start-neo4j.sh
+++ b/docker/scripts/start-neo4j.sh
@@ -4,8 +4,13 @@ echo Waiting for rdb to be available
 while ! nc -z rdb 5432; do
     sleep 0.2
 done
+PG_HOST = ${PG_HOST:-rdb}
+PG_USER = ${PG_USER:-dev}
+PG_PASSWORD = ${PG_PASSWORD:-dev}
+PG_PORT = ${PG_PORT:-5432}
+PG_DB = ${PG_DB:-askem}
 echo rdb is now available. Continuing.
-psql --command="\COPY provenance TO '/var/lib/neo4j/import/provenance.csv' WITH (FORMAT CSV, HEADER);" postgresql://dev:dev@rdb:5432/askem
+psql --command="\COPY provenance TO '/var/lib/neo4j/import/provenance.csv' WITH (FORMAT CSV, HEADER);" postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}
 
 set -m
 /startup/docker-entrypoint.sh neo4j &

--- a/docker/scripts/start-neo4j.sh
+++ b/docker/scripts/start-neo4j.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-echo Waiting for rdb to be available
-while ! nc -z rdb 5432; do
-    sleep 0.2
-done
 PG_HOST=${PG_HOST:-rdb}
 PG_USER=${PG_USER:-dev}
 PG_PASSWORD=${PG_PASSWORD:-dev}
 PG_PORT=${PG_PORT:-5432}
 PG_DB=${PG_DB:-askem}
-echo rdb is now available. Continuing.
+
+echo Waiting for ${PG_HOST} to be available
+while ! nc -z ${PG_HOST} ${PG_PORT}; do
+    sleep 0.2
+done
+echo ${PG_HOST} is now available. Continuing.
 psql --command="\COPY provenance TO '/var/lib/neo4j/import/provenance.csv' WITH (FORMAT CSV, HEADER);" postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}
 
 set -m

--- a/docker/scripts/start-neo4j.sh
+++ b/docker/scripts/start-neo4j.sh
@@ -4,11 +4,11 @@ echo Waiting for rdb to be available
 while ! nc -z rdb 5432; do
     sleep 0.2
 done
-PG_HOST = ${PG_HOST:-rdb}
-PG_USER = ${PG_USER:-dev}
-PG_PASSWORD = ${PG_PASSWORD:-dev}
-PG_PORT = ${PG_PORT:-5432}
-PG_DB = ${PG_DB:-askem}
+PG_HOST=${PG_HOST:-rdb}
+PG_USER=${PG_USER:-dev}
+PG_PASSWORD=${PG_PASSWORD:-dev}
+PG_PORT=${PG_PORT:-5432}
+PG_DB=${PG_DB:-askem}
 echo rdb is now available. Continuing.
 psql --command="\COPY provenance TO '/var/lib/neo4j/import/provenance.csv' WITH (FORMAT CSV, HEADER);" postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}
 


### PR DESCRIPTION
This PR allows us to parameterize the database connection parameters for initialization of neo4j. You can now set the PG environment via:
```
PG_HOST=...
PG_PORT=...
PG_USER=...
PG_PASSWORD=...
PG_DB=...
```
The defaults will be the same as before to allow data-service developers to run locally as usual.

This has been built manually and pushed to the registry `ghcr.io/darpa-askem/data-service-graphdb:5.3.0.3` but should likely receive some build automation.