### PR TITLE
ci: switch to use the shared workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
   formatting:
     uses: ./.github/workflows/formatting.yaml
 
-    # Call the Tag Generator to generate an image tag to use
+  # Call the Tag Generator to generate an image tag to use
   tag-generator:
     uses: darpa-askem/.github/.github/workflows/tag-generator.yaml@main
     with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,32 +18,11 @@ jobs:
   formatting:
     uses: ./.github/workflows/formatting.yaml
 
-  # Generate a more robust tag for the image
+    # Call the Tag Generator to generate an image tag to use
   tag-generator:
-    name: Determine image tag
-    runs-on: ubuntu-22.04
-    outputs:
-      image-tag: ${{ steps.generate.outputs.tag }}
-    steps:
-      - name: Generate apprropriate tag
-        id: generate
-        run: |
-          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'dev' ]]; then
-            TAG=latest
-          else
-            SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
-            if [[ -n $SEMVER ]]; then
-              TAG=${SEMVER}
-            else
-              TAG=${{ github.ref_name }}
-            fi
-          fi
-
-          echo "$TAG"
-          echo "tag=${TAG,,}" >> ${GITHUB_OUTPUT}
-
-      - name: Show Generated Tag
-        run: echo ${{ steps.generate.outputs.tag }}
+    uses: darpa-askem/.github/.github/workflows/tag-generator.yaml@main
+    with:
+      branch: 'dev'
 
   # Build and Publish all targets associated with specified group
   bake:
@@ -57,7 +36,7 @@ jobs:
       group: 'prod'
       registry: 'ghcr.io'
       organization: ${{ github.repository_owner }}
-      tag: ${{ needs.tag-generator.outputs.image-tag }}
+      tag: ${{ needs.tag-generator.outputs.tag }}
     secrets:
       username: ${{ github.repository_owner }}
       password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replacing the tag generator with the shareable one for consistency.  Workflow exposes an input called `branch` which can be used (as is here) to override the default branch to check for `latest` tag generation. Here using `dev` to match what was there before.

Currently merging to `main`, should this go into `dev` instead?