### PR TITLE
183 add neo4j to docker bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,6 +59,12 @@ target "data-service-storage-base" {
 	dockerfile = "docker/Dockerfile.minio"
 }
 
+target "data-service-graphdb-base" {
+  context = "."
+  tags = tag("data-service-graphdb", "", "")
+  dockerfile = "docker/Dockerfile.neo4j"
+}
+
 target "data-service" {
   inherits = ["_platforms", "data-service-base"]
 }
@@ -69,4 +75,8 @@ target "data-service-dev-db" {
 
 target "data-service-storage" {
   inherits = ["_platforms", "data-service-storage-base"]
+}
+
+target "data-service-graphdb" {
+  inherits = ["_platforms", "data-service-graphdb-base"]
 }


### PR DESCRIPTION
This pins the neo4j version to the one we're currently running (just in case `latest` updates behind our back) as well as adds an entry to the docker bake to ensure we get both an amd and an arm version of the image