### PR TITLE
Fix publishing latest to staging

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
   tag-generator:
     uses: darpa-askem/.github/.github/workflows/tag-generator.yaml@main
     with:
-      branch: 'dev'
+      branch: 'main'
 
   # Build and Publish all targets associated with specified group
   bake:


### PR DESCRIPTION
TDS used to have a `dev` and a `main` branch. Latest staging packages were built off of `dev` and official releases were in `main`. When we switch to having `main` be the latest release and version tags be the official production release, the `dev` artifact was left in the publish action.