### PR TITLE
Fix es client so that it does not get created prior to api kick-off

### DIFF
--- a/tds/db/__init__.py
+++ b/tds/db/__init__.py
@@ -3,7 +3,7 @@ tds.db - DB handling
 """
 
 from tds.db.alembic import stamp, upgrade
-from tds.db.elasticsearch import es
+from tds.db.elasticsearch import es_client
 from tds.db.graph.neo4j import request_engine as request_graph_db
 from tds.db.graph.provenance_handler import ProvenanceHandler
 from tds.db.graph.search_provenance import SearchProvenance

--- a/tds/db/base.py
+++ b/tds/db/base.py
@@ -3,7 +3,9 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from tds.db import es
+from tds.db import es_client
+
+es = es_client()
 
 
 class TdsModel(BaseModel):

--- a/tds/main.py
+++ b/tds/main.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import OperationalError
 from uvicorn import run as uvicorn_run
 
 from tds.db import init_dev_content, rdb, stamp, upgrade
-from tds.db.elasticsearch import es, wait_for_es_up
+from tds.db.elasticsearch import es_client, wait_for_es_up
 from tds.settings import settings
 
 logger = logging.Logger("main.py")
@@ -22,10 +22,12 @@ def setup_elasticsearch_indexes() -> None:
     # Config should match keyword args on https://elasticsearch-py.readthedocs.io/en/v8.3.2/api.html#elasticsearch.client.IndicesClient.create
     indices = {
         "model": {},
+        "dataset": {},
     }
 
     # Wait for elasticsearch to be online and healthy enough to proceed
-    wait_for_es_up()
+    es = es_client()
+    wait_for_es_up(es)
 
     # Create indexes
     for idx, config in indices.items():

--- a/tds/modules/model/controller.py
+++ b/tds/modules/model/controller.py
@@ -8,7 +8,7 @@ from elasticsearch import NotFoundError
 from fastapi import APIRouter, Response, status
 from fastapi.responses import JSONResponse
 
-from tds.db import es
+from tds.db import es_client
 from tds.modules.model.model import Model
 from tds.modules.model.model_description import ModelDescription
 from tds.modules.model.utils import model_list_response, model_response
@@ -16,6 +16,8 @@ from tds.operation import create, delete, retrieve, update
 
 model_router = APIRouter()
 logger = Logger(__name__)
+
+es = es_client()
 
 
 @model_router.get(


### PR DESCRIPTION
This fixes the bug that causes failures when trying to use a ES client from inside a child process that is defined in the parent process. This causes errors and failures when communicating with ES.

The fix chosen was to not spawn a global es client at module import time and instead to provide a factory function for fetching a new client when needed.