### PR TITLE
Allow framework failure to fall back on the URI of framework

### DIFF
--- a/tds/modules/model/utils.py
+++ b/tds/modules/model/utils.py
@@ -39,7 +39,7 @@ def model_response(model_from_es, delete_fields=None) -> dict:
     model = es_response["_source"]
     model["state_id"] = model["id"] = es_response["_id"]
     frameworks = get_frameworks()
-    model["framework"] = frameworks[model["model_schema"]]
+    model["framework"] = frameworks.get(model["model_schema"], model["model_schema"])
     model["schema"] = model["model_schema"]
 
     del model["model_schema"]
@@ -68,7 +68,7 @@ def model_list_response(model_list_from_es) -> list:
     models["model_version"] = models["model_version"].fillna(0)
     # we should use the same terminology here as is used in the ASKEM model
     # representation e.g. instead of `model_schema` that should just be `schema`
-    models["framework"] = models["model_schema"].map(lambda x: framework_map[x])
+    models["framework"] = models["model_schema"].map(lambda x: framework_map.get(x, x))
     models.rename(columns={"_id": "id", "model_schema": "schema"}, inplace=True)
     models.drop(columns=["_index", "_score"], inplace=True)
 


### PR DESCRIPTION
This fixes the `/models/descriptions` endpoint so that things don't crash if we don't have the right frameworks in place.