### PR TITLE
Added model search and updated index mappings

### DIFF
--- a/tds/main.py
+++ b/tds/main.py
@@ -34,6 +34,10 @@ def setup_elasticsearch_indexes() -> None:
                     "type": "object",
                     "enabled": False,
                 },
+                "metadata": {
+                    "type": "object",
+                    "enabled": False,
+                },
             },
         },
         "dataset": {},
@@ -44,6 +48,10 @@ def setup_elasticsearch_indexes() -> None:
                     "enabled": False,
                 },
                 "model.semantics": {
+                    "type": "object",
+                    "enabled": False,
+                },
+                "model.metadata": {
                     "type": "object",
                     "enabled": False,
                 },

--- a/tds/modules/model/controller.py
+++ b/tds/modules/model/controller.py
@@ -5,6 +5,7 @@ from logging import Logger
 from typing import Any, Dict, List
 
 from elasticsearch import NotFoundError
+from elasticsearch import exceptions as es_exceptions
 from fastapi import APIRouter, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException
@@ -83,7 +84,10 @@ def search_models(
     }
     if page != 0:
         list_body["from"] = page
-    res = es.search(index=es_index, **list_body)
+    try:
+        res = es.search(index=es_index, **list_body)
+    except es_exceptions.RequestError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     list_body = model_list_response(res["hits"]["hits"]) if res["hits"]["hits"] else []
 


### PR DESCRIPTION
## What's new

1. adds a new endpoint `/models/search` which is a `POST` that is effectively the same as `/models/descriptions` except that it accepts a JSON payload which can be any Elasticsearch query. This is simply passed along to the ES client. If the query is malformed an error is raised.
2. `metadata` for models and model configs are now treated as unindexed `objects` to avoid mapping explosion.