### PR TITLE
Fixed es mapping for model_configuration

### DIFF
--- a/tds/main.py
+++ b/tds/main.py
@@ -43,15 +43,15 @@ def setup_elasticsearch_indexes() -> None:
         "dataset": {},
         "model_configuration": {
             "properties": {
-                "model.model": {
+                "configuration.model": {
                     "type": "object",
                     "enabled": False,
                 },
-                "model.semantics": {
+                "configuration.semantics": {
                     "type": "object",
                     "enabled": False,
                 },
-                "model.metadata": {
+                "configuration.metadata": {
                     "type": "object",
                     "enabled": False,
                 },


### PR DESCRIPTION
The ES mapping was pointing to the wrong location; since we call the `model` in the model configuration `configuration` we need to rename the top keys.