### PR TITLE
Update patchable util to allow multiple uses per model

### DIFF
--- a/tds/lib/utils.py
+++ b/tds/lib/utils.py
@@ -2,19 +2,26 @@
 TDS Utilities.
 """
 
+import typing
+
 from pydantic import BaseModel
+
+_PATCHABLE_MODELS: typing.Dict[BaseModel, BaseModel] = {}
 
 
 def patchable(model: BaseModel) -> BaseModel:
     """
     Create a fully optional version of a model for use with PATCH
     """
+    model_name = f"Patchable{model.__name__}"
+    if model_name in _PATCHABLE_MODELS:
+        return _PATCHABLE_MODELS[model_name]
 
-    # Create new class that inherits from passed in class
-    class PatchableModel(model):
-        ...
+    PatchableModel = type(model_name, (model,), {})
 
     # Update the fields to be optional
     for field_def in PatchableModel.__fields__.values():
         field_def.required = False
+
+    _PATCHABLE_MODELS[model_name] = PatchableModel
     return PatchableModel


### PR DESCRIPTION
I found that the original version would choke if you tried to use the patchable util function on the same model on multiple endpoints. This allows the patchable models to be used multiple times without conflicts.