### PR TITLE
Fix artifact save

### DIFF
--- a/tds/modules/artifact/controller.py
+++ b/tds/modules/artifact/controller.py
@@ -100,7 +100,8 @@ def artifact_put(artifact_id: str, payload: Artifact) -> JSONResponse | Response
     Update a artifact in ElasticSearch
     """
     try:
-        res = payload.save(artifact_id)
+        payload.id = artifact_id
+        res = payload.save()
         logger.info("artifact updated: %s", res["_id"])
         return JSONResponse(
             status_code=status.HTTP_200_OK,


### PR DESCRIPTION
Artifacts could not be updated--it was erroring out. This fixes the situation. There's also this hidden assumption we should consider around how the `PUT` calls are expecting the `id` to exist correctly in the body. I made sure to set the `ids` explicitly in case the client doesn't have it in the payload.