### PR TITLE
Increased return size for project assets

### DIFF
--- a/tds/modules/project/controller.py
+++ b/tds/modules/project/controller.py
@@ -315,6 +315,7 @@ def get_project_assets(
                         index=index,
                         query={"ids": {"values": assets_key_ids[key]}},
                         fields=responder["fields"],
+                        size=1000,
                     )
                     assets_key_objects[key] = (
                         []


### PR DESCRIPTION
Temporary size increase for Project Assets from ES.  @brandomr We need to discuss a system default response size so we can apply it to both ES and relational data.