### PR TITLE
feat: GET `/project` should return only active ones by default

### DIFF
--- a/tds/modules/project/controller.py
+++ b/tds/modules/project/controller.py
@@ -41,7 +41,7 @@ def list_projects(rdb: Engine = Depends(request_rdb)) -> JSONResponse:
     Retrieve the list of projects.
     """
     with Session(rdb) as session:
-        projects = session.query(Project).all()
+        projects = session.query(Project).filter(Project.active == True).all()
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,


### PR DESCRIPTION
When using GET `/project`, TDS should return only the active ones, unless a flag is passed like `page_size `.