### PR TITLE
Add `header` to model

### DIFF
--- a/tds/lib/model_configs.py
+++ b/tds/lib/model_configs.py
@@ -2,10 +2,12 @@
 Model configurations to fill out Swagger doc examples.
 """
 model_config = {
-    "name": "A Test Model",
-    "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.2/petrinet/petrinet_schema.json",  # pylint: disable=line-too-long
-    "description": "Test Model Post from Swagger.",
-    "model_version": "1.0",
+    "header": {
+        "name": "A Test Model",
+        "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.2/petrinet/petrinet_schema.json",  # pylint: disable=line-too-long
+        "description": "Test Model Post from Swagger.",
+        "model_version": "1.0",
+    },
     "model": {
         "states": [
             {

--- a/tds/modules/document/controller.py
+++ b/tds/modules/document/controller.py
@@ -183,7 +183,7 @@ def document_download_url(document_id: str, filename: str) -> JSONResponse:
         entity_id=document_id,
         file_name=filename,
         method="get_object",
-        path=settings.S3_document_PATH,
+        path=settings.S3_DOCUMENT_PATH,
     )
     return JSONResponse(
         content={

--- a/tds/modules/model/model.py
+++ b/tds/modules/model/model.py
@@ -15,18 +15,22 @@ from tds.modules.concept.model import ActiveConcept, OntologyConcept
 from tds.settings import settings
 
 
+class Header(BaseModel):
+    name: str
+    description: str
+    model_schema: Optional[str] = Field(alias="schema")
+    schema_name: Optional[str]
+    model_version: str
+
+
 class Model(TdsModel):
     """
     TDS Model Data Model
     """
 
-    name: str
-    description: str
+    header: Header
     username: Optional[str]
     model: dict
-    model_schema: Optional[str] = Field(alias="schema")
-    schema_name: Optional[str]
-    model_version: str
     semantics: Optional[dict]
     metadata: Optional[dict]
 

--- a/tds/modules/model/model.py
+++ b/tds/modules/model/model.py
@@ -16,6 +16,10 @@ from tds.settings import settings
 
 
 class Header(BaseModel):
+    """
+    Header object for AMR
+    """
+
     name: str
     description: str
     model_schema: Optional[str] = Field(alias="schema")

--- a/tds/modules/model/model_description.py
+++ b/tds/modules/model/model_description.py
@@ -10,6 +10,10 @@ from tds.db.base import TdsModel
 
 
 class Header(BaseModel):
+    """
+    Header object for AMR
+    """
+
     name: str
     description: str
     model_schema: Optional[str] = Field(alias="schema")

--- a/tds/modules/model/model_description.py
+++ b/tds/modules/model/model_description.py
@@ -4,9 +4,17 @@ TDS Model Description
 from datetime import datetime
 from typing import Optional
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from tds.db.base import TdsModel
+
+
+class Header(BaseModel):
+    name: str
+    description: str
+    model_schema: Optional[str] = Field(alias="schema")
+    schema_name: Optional[str]
+    model_version: str
 
 
 class ModelDescription(TdsModel):
@@ -14,13 +22,11 @@ class ModelDescription(TdsModel):
     Model description for list response.
     """
 
-    name: str
-    description: str
+    header: Header
     username: Optional[str]
-    model_schema: Optional[str] = Field(alias="schema")
-    schema_name: Optional[str]
-    timestamp = datetime
-    model_version: str
+    timestamp: datetime = (
+        datetime.now()
+    )  # Assuming you meant it to be a default current datetime value
 
     class Config:
         """
@@ -29,10 +35,13 @@ class ModelDescription(TdsModel):
 
         schema_extra = {
             "example": {
-                "name": "Model Name",
-                "description": "Model Description",
-                "model": {},
-                "schema": "Model Schema",
-                "model_version": "1.0",
+                "header": {
+                    "name": "Model Name",
+                    "description": "Model Description",
+                    "schema": "Model Schema",
+                    "model_version": "1.0",
+                },
+                "username": "user123",
+                "timestamp": "2023-08-30T00:00:00",  # Example datetime value in ISO format
             }
         }

--- a/tds/modules/model/utils.py
+++ b/tds/modules/model/utils.py
@@ -16,6 +16,7 @@ from tds.modules.model.model_description import ModelDescription
 
 model_list_fields = [
     "id",
+    "header",
     "name",
     "model",
     "description",
@@ -42,6 +43,44 @@ def orm_to_params(parameters: List):
     ]
 
 
+def restructure_model_header(model: dict) -> dict:
+    """
+    Restructures the Model data by moving specific keys into the 'header' sub-dictionary.
+    This makes all seeds and prior models comply with https://github.com/DARPA-ASKEM/Model-Representations/issues/56
+
+    Parameters:
+    - model (dict): The original Model data.
+
+    Returns:
+    - dict: The restructured Model data.
+    """
+
+    if "header" in model:
+        return model
+
+    # The keys to be moved to the 'header'
+    header_keys = [
+        "name",
+        "description",
+        "model_schema",
+        "schema",
+        "schema_name",
+        "model_version",
+    ]
+
+    # Create the 'header' sub-dictionary
+    header_data = {key: model.pop(key) for key in header_keys if key in model}
+
+    # Rename 'schema' to 'model_schema' if present
+    if "model_schema" in header_data:
+        header_data["schema"] = header_data.pop("model_schema")
+
+    # Add the 'header' sub-dictionary to the original data
+    model["header"] = header_data
+
+    return model
+
+
 def model_response(model_from_es, delete_fields=None) -> dict:
     """
     Function builds model response object from an ElasticSearch model.
@@ -51,9 +90,13 @@ def model_response(model_from_es, delete_fields=None) -> dict:
     # model["state_id"] = es_response["_id"]
     # frameworks = get_frameworks()
     # model["framework"] = frameworks.get(model["model_schema"], model["model_schema"])
-    if "model_schema" in model:
-        model["schema"] = model["model_schema"]
-        del model["model_schema"]
+
+    model = restructure_model_header(model)
+
+    # Rename 'schema' to 'model_schema' if present
+    if "model_schema" in model["header"]:
+        model["header"]["schema"] = model["header"].pop("model_schema")
+
     if "concepts" in model:
         del model["concepts"]
 
@@ -68,6 +111,7 @@ def model_list_response(model_list_from_es) -> list:
     """
     Function builds model response object from an ElasticSearch model.
     """
+    print(model_list_from_es[0])
     model_df = pd.DataFrame(model_list_from_es)
     # framework_map = get_frameworks()
     # We need to get the fields and then merge back to make the id available.
@@ -77,12 +121,9 @@ def model_list_response(model_list_from_es) -> list:
         .join(model_df)
         .reset_index(drop=True)
     )
+
     models["model_version"] = models["model_version"].fillna(0)
-    # we should use the same terminology here as is used in the ASKEM model
-    # representation e.g. instead of `model_schema` that should just be `schema`
-    # models["framework"] = models["model_schema"].map(
-    #   lambda x: framework_map.get(x, x)
-    # )
+
     models.drop(columns=["_index", "_score"], inplace=True)
 
     # Drop _ignored column when it is present.
@@ -90,7 +131,7 @@ def model_list_response(model_list_from_es) -> list:
         models.drop(columns=["_ignored"], inplace=True)
 
     return [
-        jsonable_encoder(ModelDescription(**x))
+        jsonable_encoder(ModelDescription(**restructure_model_header(x)))
         for x in models.to_dict(orient="records")
     ]
 

--- a/tds/modules/model/utils.py
+++ b/tds/modules/model/utils.py
@@ -55,28 +55,26 @@ def restructure_model_header(model: dict) -> dict:
     - dict: The restructured Model data.
     """
 
-    if "header" in model:
-        return model
+     if "header" not in model:
+        # The keys to be moved to the 'header'
+        header_keys = [
+            "name",
+            "description",
+            "model_schema",
+            "schema",
+            "schema_name",
+            "model_version",
+        ]
 
-    # The keys to be moved to the 'header'
-    header_keys = [
-        "name",
-        "description",
-        "model_schema",
-        "schema",
-        "schema_name",
-        "model_version",
-    ]
+        # Create the 'header' sub-dictionary
+        header_data = {key: model.pop(key) for key in header_keys if key in model}
 
-    # Create the 'header' sub-dictionary
-    header_data = {key: model.pop(key) for key in header_keys if key in model}
+        # Add the 'header' sub-dictionary to the original data
+        model["header"] = header_data
 
     # Rename 'schema' to 'model_schema' if present
     if "model_schema" in header_data:
         header_data["schema"] = header_data.pop("model_schema")
-
-    # Add the 'header' sub-dictionary to the original data
-    model["header"] = header_data
 
     return model
 

--- a/tds/modules/model/utils.py
+++ b/tds/modules/model/utils.py
@@ -47,15 +47,13 @@ def restructure_model_header(model: dict) -> dict:
     """
     Restructures the Model data by moving specific keys into the 'header' sub-dictionary.
     This makes all seeds and prior models comply with https://github.com/DARPA-ASKEM/Model-Representations/issues/56
-
     Parameters:
     - model (dict): The original Model data.
-
     Returns:
     - dict: The restructured Model data.
     """
 
-     if "header" not in model:
+    if "header" not in model:
         # The keys to be moved to the 'header'
         header_keys = [
             "name",
@@ -91,10 +89,6 @@ def model_response(model_from_es, delete_fields=None) -> dict:
 
     model = restructure_model_header(model)
 
-    # Rename 'schema' to 'model_schema' if present
-    if "model_schema" in model["header"]:
-        model["header"]["schema"] = model["header"].pop("model_schema")
-
     if "concepts" in model:
         del model["concepts"]
 
@@ -109,7 +103,7 @@ def model_list_response(model_list_from_es) -> list:
     """
     Function builds model response object from an ElasticSearch model.
     """
-    print(model_list_from_es[0])
+
     model_df = pd.DataFrame(model_list_from_es)
     # framework_map = get_frameworks()
     # We need to get the fields and then merge back to make the id available.


### PR DESCRIPTION
This PR is in support of https://github.com/DARPA-ASKEM/Model-Representations/issues/56 which requires that various fields be nested under `header` in the AMR.

The goal of this PR is to flexibly support this new request while not forcing breakage of all existing AMRs by adding a helper utility to `tds/modules/model/utils.py` called `restructure_model_header` which checks to see if the `header` exists and if not, performs the requisite nesting.

Until this is merged, all TA1 produced AMRs will be rejected by TDS since they now have the `header`.