### PR TITLE
Refactor `Code` model

### DIFF
--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -31,7 +31,7 @@ class Code(TdsModel):
 
     name: str = Field(description="Name of the code/repo.")
     description: str = Field(description="Description for code/repo.")
-    files: Dict[str, CodeFile] = Field(
+    files: Optional[Dict[str, CodeFile]] = Field(
         description="Dictionary of code files with file paths as keys."
     )
     repo_url: Optional[str] = Field(

--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -1,7 +1,7 @@
 """
 TDS Code Data Model Definition.
 """
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,7 +15,7 @@ class CodeFile(BaseModel):
     """
 
     path: str = Field(description="Path to the file within the repository.")
-    language: ProgrammingLanguage = Field(
+    language: Optional[ProgrammingLanguage] = Field(
         description="Programming language of the file."
     )
     dynamics: Optional[str] = Field(
@@ -36,9 +36,6 @@ class Code(TdsModel):
     )
     repo_url: Optional[str] = Field(
         None, description="URL to the repository where the code resides."
-    )
-    tree_structure: dict = Field(
-        description="JSON representation of the tree structure of the code."
     )
     commit: Optional[str] = Field(None, description="Commit hash or ID for the repo.")
     branch: Optional[str] = Field(None, description="Branch name of the repo.")
@@ -68,7 +65,6 @@ class Code(TdsModel):
                         "dynamics": "L205-L213",
                     },
                 },
-                "tree_structure": {},
                 "repo_url": "https://github.com/user/repo.git",
                 "commit": "abcd1234",
                 "branch": "main",

--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -14,7 +14,6 @@ class CodeFile(BaseModel):
     CodeFile Data Model for individual file entries in the main Code model.
     """
 
-    path: str = Field(description="Path to the file within the repository.")
     language: Optional[ProgrammingLanguage] = Field(
         description="Programming language of the file."
     )

--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -8,15 +8,26 @@ from pydantic import BaseModel, Field
 from tds.db.base import TdsModel
 
 
+class Dynamics(BaseModel):
+    """
+    Dynamics Data Model for capturing dynamics within a CodeFile.
+    """
+
+    name: Optional[str] = Field(description="Name of the dynamics section.")
+    description: Optional[str] = Field(description="Description of the dynamics.")
+    block: str = Field(
+        description="String indicating the line numbers in the file that contain the dynamics, e.g., 'L205-L213'."
+    )
+
+
 class CodeFile(BaseModel):
     """
     CodeFile Data Model for individual file entries in the main Code model.
     """
 
     language: Optional[str] = Field(description="Programming language of the file.")
-    dynamics: Optional[str] = Field(
-        None,
-        description="String indicating the line numbers in the file that contain the dynamics, e.g., 'L205-L213'.",
+    dynamics: Optional[Dynamics] = Field(
+        description="Dynamics details associated with the file."
     )
 
 
@@ -52,13 +63,15 @@ class Code(TdsModel):
                 "description": "Example of a Python-based code object for a model",
                 "files": {
                     "path/to/test.py": {
-                        "path": "path/to/test.py",
                         "language": "python",
                     },
                     "path/to/fun.py": {
-                        "path": "path/to/fun.py",
                         "language": "python",
-                        "dynamics": "L205-L213",
+                        "dynamics": {
+                            "name": "Main Dynamics",
+                            "description": "Dynamics section for the ODE.",
+                            "block": "L205-L213",
+                        },
                     },
                 },
                 "repo_url": "https://github.com/user/repo.git",

--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -1,10 +1,27 @@
 """
 TDS Code Data Model Definition.
 """
-from typing import Optional
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
 
 from tds.db.base import TdsModel
 from tds.db.enums import ProgrammingLanguage
+
+
+class CodeFile(BaseModel):
+    """
+    CodeFile Data Model for individual file entries in the main Code model.
+    """
+
+    path: str = Field(description="Path to the file within the repository.")
+    language: ProgrammingLanguage = Field(
+        description="Programming language of the file."
+    )
+    dynamics: Optional[str] = Field(
+        None,
+        description="String indicating the line numbers in the file that contain the dynamics, e.g., 'L205-L213'.",
+    )
 
 
 class Code(TdsModel):
@@ -12,12 +29,22 @@ class Code(TdsModel):
     Code Data Model
     """
 
-    name: str
-    description: str
-    filename: str
-    repo_url: Optional[str]
-    language: ProgrammingLanguage
-    metadata: Optional[dict]
+    name: str = Field(description="Name of the code/repo.")
+    description: str = Field(description="Description for code/repo.")
+    files: Dict[str, CodeFile] = Field(
+        description="Dictionary of code files with file paths as keys."
+    )
+    repo_url: Optional[str] = Field(
+        None, description="URL to the repository where the code resides."
+    )
+    tree_structure: dict = Field(
+        description="JSON representation of the tree structure of the code."
+    )
+    commit: Optional[str] = Field(None, description="Commit hash or ID for the repo.")
+    branch: Optional[str] = Field(None, description="Branch name of the repo.")
+    metadata: Optional[dict] = Field(
+        None, description="Optional metadata associated with the code."
+    )
 
     _index = "code"
 
@@ -29,8 +56,21 @@ class Code(TdsModel):
         schema_extra = {
             "example": {
                 "name": "Example Model Code",
-                "description": "Example of a Python based code object for a model",
-                "filename": "code.py",
-                "language": "python",
+                "description": "Example of a Python-based code object for a model",
+                "files": {
+                    "path/to/test.py": {
+                        "path": "path/to/test.py",
+                        "language": "python",
+                    },
+                    "path/to/fun.py": {
+                        "path": "path/to/fun.py",
+                        "language": "python",
+                        "dynamics": "L205-L213",
+                    },
+                },
+                "tree_structure": {},
+                "repo_url": "https://github.com/user/repo.git",
+                "commit": "abcd1234",
+                "branch": "main",
             }
         }

--- a/tds/modules/code/model.py
+++ b/tds/modules/code/model.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from tds.db.base import TdsModel
-from tds.db.enums import ProgrammingLanguage
 
 
 class CodeFile(BaseModel):
@@ -14,9 +13,7 @@ class CodeFile(BaseModel):
     CodeFile Data Model for individual file entries in the main Code model.
     """
 
-    language: Optional[ProgrammingLanguage] = Field(
-        description="Programming language of the file."
-    )
+    language: Optional[str] = Field(description="Programming language of the file.")
     dynamics: Optional[str] = Field(
         None,
         description="String indicating the line numbers in the file that contain the dynamics, e.g., 'L205-L213'.",

--- a/tds/modules/code/response.py
+++ b/tds/modules/code/response.py
@@ -1,7 +1,7 @@
 """
 TDS Code Response object.
 """
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel
 
@@ -16,9 +16,10 @@ class CodeResponse(BaseModel):
     id: str
     name: str
     description: str
-    filename: str
+    files: Optional[Dict]
     repo_url: Optional[str]
-    language: ProgrammingLanguage
+    commit: Optional[str]
+    branch: Optional[str]
     metadata: Optional[dict]
 
 


### PR DESCRIPTION
This PR addresses #327 

> Note: it does not implement a `tree` but instead relies on the keys of `files` which are the full path of the file relative to the root of the repo to describe the tree structure.

An example `Code` object might look like:

```
{
   "name":"Example Model Code",
   "description":"Example of a Python-based code object for a model",
   "files":{
      "README.md":{
         "language":"markdown"
      },
      "src/model.py":{
         "language":"python",
         "dynamics":{
            "name":"Main Dynamics",
            "description":"Dynamics section for the ODE.",
            "block":"L205-L213"
         }
      }
   },
   "repo_url":"https://github.com/user/repo.git",
   "commit":"abcd1234",
   "branch":"main",
   "metadata":{
      
   }
}
```

The HMI can obtain the `tree` by grabbing the `keys` of `files`:

```
README.md
src/model.py
```

This implies that `README.md` is at the top level of the repo whereas `model.py` is in the `src` directory.

