### PR TITLE
Allow for specification of `id` on creation of models and datasets

### DIFF
--- a/tds/modules/dataset/controller.py
+++ b/tds/modules/dataset/controller.py
@@ -45,7 +45,7 @@ def create_dataset(payload: Dataset) -> JSONResponse:
     """
     Create model and return its ID
     """
-    res = payload.create()
+    res = payload.save()
     logger.info("New dataset created: %s", id)
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,

--- a/tds/modules/model/controller.py
+++ b/tds/modules/model/controller.py
@@ -111,7 +111,7 @@ def model_post(payload: Model) -> JSONResponse:
     Create model and return its ID
     """
 
-    res = payload.create()
+    res = payload.save()
     logger.info("new model created: %s", res["_id"])
     return JSONResponse(
         status_code=status.HTTP_200_OK,


### PR DESCRIPTION
This will let us "overwrite" in place some special models/datasets for our integration dashboard. This is already standard for `code` and `documents.