### PR TITLE
Fix to enable fetching equation assets off a project

### DIFF
--- a/tds/modules/project/controller.py
+++ b/tds/modules/project/controller.py
@@ -295,6 +295,7 @@ def get_project_assets(
             ResourceType.artifacts,
             ResourceType.code,
             ResourceType.documents,
+            ResourceType.equations,
         ]
     ),
     rdb: Engine = Depends(request_rdb),

--- a/tds/modules/project/helpers.py
+++ b/tds/modules/project/helpers.py
@@ -12,6 +12,7 @@ from tds.modules.artifact.response import artifact_response
 from tds.modules.code.response import code_response
 from tds.modules.dataset.response import dataset_response
 from tds.modules.document.response import document_response
+from tds.modules.equation.response import equation_response
 from tds.modules.model.utils import model_list_fields, model_list_response
 from tds.modules.model_configuration.response import configuration_response
 from tds.modules.project.model import Project, ProjectAsset
@@ -32,6 +33,7 @@ es_list_response = {
     ResourceType.artifacts: {"fields": None, "function": artifact_response},
     ResourceType.code: {"fields": None, "function": code_response},
     ResourceType.documents: {"fields": None, "function": document_response},
+    ResourceType.equations: {"fields": None, "function": equation_response},
 }
 
 es_resources = list(es_list_response.keys())

--- a/tds/schema/resource.py
+++ b/tds/schema/resource.py
@@ -10,6 +10,7 @@ from tds.modules.artifact.model import Artifact
 from tds.modules.code.model import Code
 from tds.modules.dataset.model import Dataset
 from tds.modules.document.model import Document
+from tds.modules.equation.model import Equation
 from tds.modules.external.model import Publication, SoftwarePayload
 from tds.modules.model.model import Model
 from tds.modules.model_configuration.model import ModelConfiguration
@@ -31,6 +32,7 @@ Resource = (
     | Publication
     | Simulation
     | Workflow
+    | Equation
 )
 
 ORMResource = Dataset | Publication | Simulation
@@ -45,6 +47,7 @@ obj_to_enum: Dict[Type[Resource], ResourceType] = {
     Publication: ResourceType.publications,
     Simulation: ResourceType.simulations,
     Workflow: ResourceType.workflows,
+    Equation: ResourceType.equations,
 }
 
 


### PR DESCRIPTION
Addresses #355 

To Test:

1. create an equation (with default)
2. create a project (or use one of the seeds)
3. add equation as asset to project
4. get project assets (can filter for only equations if you'd like)
5. confirm equation is in assets
6. delete equation asset from project
7. confirm deletion went through by fetching project asset