### PR TITLE
Allow models/datasets to be extracted from `publications`

### DIFF
--- a/graph_relations.json
+++ b/graph_relations.json
@@ -35,7 +35,9 @@
         ["Dataset","Document"],
         ["Model", "Code"],
         ["Model","Equation"],
-        ["Equation", "Document"]
+        ["Equation", "Document"],
+        ["Model", "Publication"],
+        ["Dataset", "Publication"]
     ],
     "CONTAINS":[
         ["Project","Document"],

--- a/tds/schema/provenance.py
+++ b/tds/schema/provenance.py
@@ -51,4 +51,5 @@ provenance_type_to_abbr: Dict[Type[ProvenanceType], str] = {
     ProvenanceType.Artifact: "Ar",
     ProvenanceType.Code: "Co",
     ProvenanceType.Equation: "Eq",
+    ProvenanceType.Publication: "Pu",
 }


### PR DESCRIPTION
Addresses #360. 

@dvince2 are there other things that should be able to be `EXTRACTED_FROM` a publication?

To get this to work you'd first `POST /provenance` a new provenance:

```
{
  "relation_type": "EXTRACTED_FROM",
  "left": "my-model-id",
  "left_type": "Model",
  "right": "my-publication-id",
  "right_type": "Publication"
}
```

Then a search like the following `POST /provenance/search?search_type=connected_nodes`:

```
{
   "root_id":"my-publication-id",
   "root_type":"Publication",
   "nodes":true,
   "types":[
      "Concept",
      "Dataset",
      "Model",
      "ModelConfiguration",
      "Project",
      "Publication",
      "Simulation",
      "Artifact",
      "Code",
      "Document",
      "Equation"
   ],
   "hops":1,
   "limit":10,
   "verbose":true
}
```

will yield:

```
{
  "result": {
    "nodes": [
      {
        "type": "Model",
        "id": "my-model-id",
        "uuid": "models/my-model-id"
      }
    ]
  }
}
```